### PR TITLE
Add safe decompress! function

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LibLZO"
 uuid = "32aa4ff1-cc5a-4ead-abec-09bb076ef871"
 authors = ["Phil Killewald <reallyasi9@users.noreply.github.com> and contributors"]
-version = "1.2.0"
+version = "2.0.0"
 
 [deps]
 LZO_jll = "dd4b983a-f0e5-5f8d-a1b7-129d4a5fb1ac"

--- a/src/LibLZO.jl
+++ b/src/LibLZO.jl
@@ -2,7 +2,7 @@ module LibLZO
 using LZO_jll
 
 export compress, unsafe_compress!
-export decompress, unsafe_decompress!
+export decompress, decompress!, unsafe_decompress!
 export optimize!, unsafe_optimize!
 export compression_level
 

--- a/src/LibLZO.jl
+++ b/src/LibLZO.jl
@@ -1,5 +1,5 @@
 module LibLZO
-using LZO_jll
+using LZO_jll: liblzo2
 
 export compress, unsafe_compress!
 export decompress, decompress!, unsafe_decompress!

--- a/src/lzo1b.jl
+++ b/src/lzo1b.jl
@@ -46,6 +46,11 @@ function decompress(::Type{LZO1B}, src; kwargs...)
     return decompress(algo, src)
 end
 
+function decompress!(::Type{LZO1B}, dest, src; kwargs...)
+    algo = LZO1B(working_memory = UInt8[])
+    return decompress!(algo, dest, src)
+end
+
 compression_level(algo::LZO1B) = algo.compression_level
 
 """
@@ -71,4 +76,5 @@ end
 for algo = (:LZO1B_99,)
     @eval unsafe_decompress!(::$algo, dest::AbstractVector{UInt8}, src::AbstractVector{UInt8}) = unsafe_decompress!(LZO1B, dest, src)
     @eval decompress(::$algo, src::AbstractVector{UInt8}) = decompress(LZO1B, src)
+    @eval decompress!(::$algo, dest::AbstractVector{UInt8}, src::AbstractVector{UInt8}) = decompress!(LZO1B, dest, src)
 end

--- a/src/lzo1c.jl
+++ b/src/lzo1c.jl
@@ -47,6 +47,11 @@ function decompress(::Type{LZO1C}, src; kwargs...)
     return decompress(algo, src)
 end
 
+function decompress!(::Type{LZO1C}, dest, src; kwargs...)
+    algo = LZO1C(working_memory = UInt8[])
+    return decompress!(algo, dest, src)
+end
+
 compression_level(algo::LZO1C) = algo.compression_level
 
 """
@@ -91,4 +96,5 @@ end
 for algo = (:LZO1C_99, :LZO1C_999)
     @eval unsafe_decompress!(::$algo, dest::AbstractVector{UInt8}, src::AbstractVector{UInt8}) = unsafe_decompress!(LZO1C, dest, src)
     @eval decompress(::$algo, src::AbstractVector{UInt8}) = decompress(LZO1C, src)
+    @eval decompress!(::$algo, dest::AbstractVector{UInt8}, src::AbstractVector{UInt8}) = decompress!(LZO1C, dest, src)
 end

--- a/src/lzo1f.jl
+++ b/src/lzo1f.jl
@@ -41,6 +41,11 @@ function decompress(::Type{LZO1F_1}, src; kwargs...)
     return decompress(algo, src)
 end
 
+function decompress!(::Type{LZO1F_1}, dest, src; kwargs...)
+    algo = LZO1F_1(working_memory = UInt8[])
+    return decompress!(algo, dest, src)
+end
+
 # special version: because LZO1F_1 does not need working memory, save on the allocations
 function unsafe_decompress!(::Type{LZO1F_1}, dest, src; kwargs...)
     algo = LZO1F_1(working_memory = UInt8[])
@@ -70,4 +75,5 @@ end
 for algo = (:LZO1F_999,)
     @eval unsafe_decompress!(::$algo, dest::AbstractVector{UInt8}, src::AbstractVector{UInt8}) = unsafe_decompress!(LZO1F_1, dest, src)
     @eval decompress(::$algo, src::AbstractVector{UInt8}) = decompress(LZO1F_1, src)
+    @eval decompress!(::$algo, dest::AbstractVector{UInt8}, src::AbstractVector{UInt8}) = decompress!(LZO1F_1, dest, src)
 end

--- a/src/lzo1x.jl
+++ b/src/lzo1x.jl
@@ -51,6 +51,11 @@ function decompress(::Type{LZO1X_1}, src; kwargs...)
     return decompress(algo, src)
 end
 
+function decompress!(::Type{LZO1X_1}, dest, src; kwargs...)
+    algo = LZO1X_1(working_memory = UInt8[])
+    return decompress!(algo, dest, src)
+end
+
 function _ccall_optimize!(algo::LZO1X_1, dest::Ptr{UInt8}, dest_size::Integer, src::Ptr{UInt8}, src_size::Integer)
     size_ptr = Ref{Csize_t}(dest_size)
     err = @ccall liblzo2.lzo1x_optimize(src::Ptr{Cuchar}, src_size::Csize_t, dest::Ptr{Cuchar}, size_ptr::Ptr{Csize_t}, algo.working_memory::Ptr{Cvoid})::Cint
@@ -153,6 +158,7 @@ compression_level(algo::LZO1X_999) = algo.compression_level
 for algo = (:LZO1X_1_11, :LZO1X_1_12, :LZO1X_1_15, :LZO1X_999)
     @eval unsafe_decompress!(::$algo, dest::AbstractVector{UInt8}, src::AbstractVector{UInt8}) = unsafe_decompress!(LZO1X_1, dest, src)
     @eval decompress(::$algo, src::AbstractVector{UInt8}) = decompress(LZO1X_1, src)
+    @eval decompress!(::$algo, dest::AbstractVector{UInt8}, src::AbstractVector{UInt8}) = decompress!(LZO1X_1, dest, src)
 end
 
 # all LZO1X algorithms use the same optimization algorithm

--- a/src/lzo1y.jl
+++ b/src/lzo1y.jl
@@ -47,6 +47,11 @@ function decompress(::Type{LZO1Y_1}, src; kwargs...)
     return decompress(algo, src)
 end
 
+function decompress!(::Type{LZO1Y_1}, dest, src; kwargs...)
+    algo = LZO1Y_1(working_memory = UInt8[])
+    return decompress!(algo, dest, src)
+end
+
 function _ccall_optimize!(algo::LZO1Y_1, dest::Ptr{UInt8}, dest_size::Integer, src::Ptr{UInt8}, src_size::Integer)
     size_ptr = Ref{Csize_t}(dest_size)
     err = @ccall liblzo2.lzo1y_optimize(src::Ptr{Cuchar}, src_size::Csize_t, dest::Ptr{Cuchar}, size_ptr::Ptr{Csize_t}, algo.working_memory::Ptr{Cvoid})::Cint
@@ -92,6 +97,7 @@ compression_level(algo::LZO1Y_999) = algo.compression_level
 for algo = (:LZO1Y_999,)
     @eval unsafe_decompress!(::$algo, dest::AbstractVector{UInt8}, src::AbstractVector{UInt8}) = unsafe_decompress!(LZO1Y_1, dest, src)
     @eval decompress(::$algo, src::AbstractVector{UInt8}) = decompress(LZO1Y_1, src)
+    @eval decompress!(::$algo, dest::AbstractVector{UInt8}, src::AbstractVector{UInt8}) = decompress!(LZO1Y_1, dest, src)
 end
 
 # all LZO1Y algorithms use the same optimization algorithm

--- a/src/lzo1z.jl
+++ b/src/lzo1z.jl
@@ -48,4 +48,9 @@ function decompress(::Type{LZO1Z_999}, src; kwargs...)
     return decompress(algo, src)
 end
 
+function decompress!(::Type{LZO1Z_999}, dest, src; kwargs...)
+    algo = LZO1Z_999(working_memory = UInt8[])
+    return decompress!(algo, dest, src)
+end
+
 compression_level(algo::LZO1Z_999) = algo.compression_level

--- a/src/lzo2a.jl
+++ b/src/lzo2a.jl
@@ -46,6 +46,11 @@ function decompress(::Type{LZO2A_999}, src; kwargs...)
     return decompress(algo, src)
 end
 
+function decompress!(::Type{LZO2A_999}, dest, src; kwargs...)
+    algo = LZO2A_999(working_memory = UInt8[])
+    return decompress!(algo, dest, src)
+end
+
 function max_compressed_length(::LZO2A_999, n::Integer)
     n == 0 && return 0 # nothing compresses to nothing
     # return (n <= 18 ? 1 : (((n - 18) ÷ 255) + 2)) + n + 3


### PR DESCRIPTION
This changes the API. While there are no backwards-incompatible changes, the added exported function necessitates a bump in major version.

This is primarily needed for use with CodecLZOP.jl, which will crash hard if the size of the decompressed data is misread from the stream and unsafe_decompress! is used. A safer decompress! method means that the codec will instead throw an exception rather than write past the end of the buffer.